### PR TITLE
fix for appararent mis use of variable  tpf vs tpf2 in read_nsstbu…

### DIFF
--- a/src/gsi/cmake/gsiapp_compiler_flags_Intel_Fortran.cmake
+++ b/src/gsi/cmake/gsiapp_compiler_flags_Intel_Fortran.cmake
@@ -14,7 +14,7 @@ set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -fp-model strict")
 # DEBUG FLAGS
 ####################################################################
 
-set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -fp-model source -debug -ftrapuv -warn all,nointerfaces -check all,noarg_temp_created -fp-stack-check -fstack-protector")
+set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -init=snan,arrays -fp-model source -debug -ftrapuv -warn all,nointerfaces -check all,noarg_temp_created -fp-stack-check -fstack-protector")
 
 ####################################################################
 # LINK FLAGS

--- a/src/gsi/read_nsstbufr.f90
+++ b/src/gsi/read_nsstbufr.f90
@@ -542,9 +542,10 @@ subroutine read_nsstbufr(nread,ndata,nodata,gstime,infile,obstype,lunout, &
               kx = 197
               sstoe = one
            elseif ( trim(subset) == 'NC031002' ) then                            ! TESAC
-              if (  tpf(1,1) >= one .and.  tpf(1,1) < 20.0_r_kind ) then
-                 zob = tpf(1,1)
-              elseif (  tpf(1,1) >= zero .and. tpf(1,1) < one ) then
+!clt
+              if (  tpf2(1,1) >= one .and.  tpf2(1,1) < 20.0_r_kind ) then
+                 zob = tpf2(1,1)
+              elseif (  tpf2(1,1) >= zero .and. tpf2(1,1) < one ) then
                  zob = one
               endif
               kx = 198   
@@ -553,9 +554,10 @@ subroutine read_nsstbufr(nread,ndata,nodata,gstime,infile,obstype,lunout, &
               kx = 199                                                           ! classify argo & glider to be bathy type
               sstoe = r0_6
            elseif ( trim(subset) == 'NC031001' ) then                            ! BATHY
-              if (  tpf(1,1) >= one .and.  tpf(1,1) <= 20.0_r_kind ) then
-                 zob = tpf(1,1)
-              elseif (  tpf(1,1) >= zero .and. tpf(1,1) < one ) then
+!clt
+              if (  tpf2(1,1) >= one .and.  tpf2(1,1) <= 20.0_r_kind ) then
+                 zob = tpf2(1,1)
+              elseif (  tpf2(1,1) >= zero .and. tpf2(1,1) < one ) then
                  zob = one
               endif
               kx = 199
@@ -566,7 +568,6 @@ subroutine read_nsstbufr(nread,ndata,nodata,gstime,infile,obstype,lunout, &
            endif
 !
 !          Determine usage
-!
            ikx = 0
            do i = 1, nconvtype
               if(kx == ictype(i) .and. abs(icuse(i))== 1) ikx=i


### PR DESCRIPTION
By adding extra debug compiler options, when running the regression test : global_4densvar,  it was found variables are used while not defined/assigned values as expected in read_nsstbufr.f90
Fix was done but hope for sat da experts to confirm the fix. 


